### PR TITLE
Fix online status on heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python bot.py
+worker: python bot.py


### PR DESCRIPTION
Heroku ne détecte pas que l'application est ligne car il n'y a pas de serveur web.
La solution proposée est de transformer l'instance heroku de `web` en `worker` 